### PR TITLE
You want to scale the predation rate, not the predation mortality

### DIFF
--- a/therMizer_extension.Rmd
+++ b/therMizer_extension.Rmd
@@ -188,10 +188,10 @@ scaled_temp_effect <- function(t) {
     scaled_temp_effect
 }
 
-therMizerEncounter <- function(params, n, n_pp, n_other, t, ...) {
+therMizerEncounter <- function(params, t, ...) {
     
       # Calculate maximum possible encounter rate
-      max_encounter <- mizerEncounter(params, n = n, n_pp = n_pp, n_other = n_other, t, ...)
+      max_encounter <- mizerEncounter(params, t, ...)
       
       # Apply temperature effect
       # return(sweep(max_encounter, 1, scaled_temp_effect, '*', check.margin = FALSE))
@@ -199,10 +199,10 @@ therMizerEncounter <- function(params, n, n_pp, n_other, t, ...) {
       
 }
 
-therMizerPredMort <- function(params, n, n_pp, n_other, t, ...) {
+therMizerPredMort <- function(params, t, ...) {
 
       # Calculate maximum possible encounter rate
-      max_predmort <- mizerPredMort(params, n = n, n_pp = n_pp, n_other = n_other, t, ...)
+      max_predmort <- mizerPredMort(params, t, ...)
       
       # Apply temperature effect
       # return(sweep(max_predmort, 1, scaled_temp_effect, '*', check.margin = FALSE))
@@ -210,10 +210,10 @@ therMizerPredMort <- function(params, n, n_pp, n_other, t, ...) {
       
 }
 
-therMizerResourceMort <- function(params, n, n_pp, n_other, t, ...) {
+therMizerResourceMort <- function(params, t, ...) {
       
       # Calculate maximum possible encounter rate
-      max_resourcemort <- mizerResourceMort(params, n = n, n_pp = n_pp, n_other = n_other, t, ...)
+      max_resourcemort <- mizerResourceMort(params, t, ...)
       
       # Apply temperature effect
       # return(sweep(max_resourcemort, 1, scaled_temp_effect, '*', check.margin = FALSE))
@@ -227,8 +227,7 @@ To calculate the effect of temperature on metabolism, we use an Arrhenius functi
 
 ```{r}
 
-therMizerEReproAndGrowth <- function(params, n, n_pp, n_other, t, encounter,
-                                 feeding_level, ...) {
+therMizerEReproAndGrowth <- function(params, t, encounter, feeding_level, ...) {
     
     # Using t+1 to avoid calling ocean_temp[0,] at the first time step
     temp_at_t <- other_params(params)$ocean_temp[t + 1,]

--- a/therMizer_extension.Rmd
+++ b/therMizer_extension.Rmd
@@ -195,25 +195,14 @@ therMizerEncounter <- function(params, t, ...) {
       
 }
 
-therMizerPredMort <- function(params, t, ...) {
+therMizerPredRate <- function(params, t, ...) {
 
       # Calculate maximum possible encounter rate
-      max_predmort <- mizerPredMort(params, t, ...)
+      max_predrate <- mizerPredRate(params, t, ...)
       
       # Apply temperature effect
-      # return(sweep(max_predmort, 1, scaled_temp_effect, '*', check.margin = FALSE))
-      return(max_predmort * scaled_temp_effect(t))
-      
-}
-
-therMizerResourceMort <- function(params, t, ...) {
-      
-      # Calculate maximum possible encounter rate
-      max_resourcemort <- mizerResourceMort(params, t, ...)
-      
-      # Apply temperature effect
-      # return(sweep(max_resourcemort, 1, scaled_temp_effect, '*', check.margin = FALSE))
-      return(max_resourcemort * scaled_temp_effect(t))
+      # return(sweep(max_predrate, 1, scaled_temp_effect, '*', check.margin = FALSE))
+      return(max_predrate * scaled_temp_effect(t))
       
 }
 
@@ -254,8 +243,7 @@ therMizerEReproAndGrowth <- function(params, t, encounter, feeding_level, ...) {
 ```{r}
 
 params <- setRateFunction(params, "Encounter", "therMizerEncounter")
-params <- setRateFunction(params, "PredMort", "therMizerPredMort")
-params <- setRateFunction(params, "ResourceMort", "therMizerResourceMort")
+params <- setRateFunction(params, "PredRate", "therMizerPredRate")
 params <- setRateFunction(params, "EReproAndGrowth", "therMizerEReproAndGrowth")
 ```
 

--- a/therMizer_extension.Rmd
+++ b/therMizer_extension.Rmd
@@ -176,14 +176,10 @@ scaled_temp_effect <- function(t) {
     scaled_temp_effect <- unscaled_temp_effect / species_params(params)$encounterpred_scale
     
     # Set temperature effect to 0 if temperatures are outside thermal tolerance limits
-    above_max <- which(temp_at_t > species_params(params)$temp_max) 
-    below_min <- which(temp_at_t < species_params(params)$temp_min) 
+    above_max <- temp_at_t > species_params(params)$temp_max
+    below_min <- temp_at_t < species_params(params)$temp_min
     
-    if (length(above_max) > 0) 
-        scaled_temp_effect[above_max] = 0
-    
-    if (length(below_min) > 0) 
-        scaled_temp_effect[below_min] = 0 
+    scaled_temp_effect[above_max | below_min] = 0
     
     scaled_temp_effect
 }
@@ -239,14 +235,10 @@ therMizerEReproAndGrowth <- function(params, t, encounter, feeding_level, ...) {
 		temp_effect_metabolism <- (unscaled_temp_effect - species_params(params)$metab_min) / species_params(params)$metab_range
 		
 		# Set temperature effect to 0 if temperatures are outside thermal tolerance limits
-    above_max <- which(temp_at_t > species_params(params)$temp_max) 
-    below_min <- which(temp_at_t < species_params(params)$temp_min) 
+    above_max <- temp_at_t > species_params(params)$temp_max
+    below_min <- temp_at_t < species_params(params)$temp_min
     
-    if (length(above_max) > 0) 
-      temp_effect_metabolism[above_max] = 0
-    
-    if (length(below_min) > 0) 
-      temp_effect_metabolism[below_min] = 0
+    temp_effect_metabolism[above_max | below_min] = 0
   
 		# Apply scaled Arrhenius value to metabolism
     sweep((1 - feeding_level) * encounter, 1,

--- a/therMizer_extension.Rmd
+++ b/therMizer_extension.Rmd
@@ -161,93 +161,63 @@ To scale encounter rate and predation mortality with temperature, we're essentia
 
 ```{r}
 
-therMizerEncounter <- function(params, n, n_pp, n_other, t, ...) {
-      
-      # Using t+1 to avoid calling ocean_temp[0,] at the first time step
-      temp_at_t <- other_params(params)$ocean_temp[t + 1,]
-  
-      # Calculate unscaled temperature effect using a generic polynomial rate equation
-      unscaled_temp_effect <- temp_at_t * (temp_at_t - species_params(params)$temp_min) * (species_params(params)$temp_max - temp_at_t)
-      
-      # Scale using new parameter
-      scaled_temp_effect <- unscaled_temp_effect / species_params(params)$encounterpred_scale
-      
-      # Set temperature effect to 0 if temperatures are outside thermal tolerance limits
-      above_max <- which(temp_at_t > species_params(params)$temp_max) 
-      below_min <- which(temp_at_t < species_params(params)$temp_min) 
-      
-      if (length(above_max) > 0) 
+# Calculate the temperature scaling factor for the encounter rate, 
+# predation mortality rate and resource mortality rate
+scaled_temp_effect <- function(t) {
+    # Using t+1 to avoid calling ocean_temp[0,] at the first time step
+    temp_at_t <- other_params(params)$ocean_temp[t + 1,]
+    
+    # Calculate unscaled temperature effect using a generic polynomial rate equation
+    unscaled_temp_effect <- 
+        temp_at_t * (temp_at_t - species_params(params)$temp_min) * 
+        (species_params(params)$temp_max - temp_at_t)
+    
+    # Scale using new parameter
+    scaled_temp_effect <- unscaled_temp_effect / species_params(params)$encounterpred_scale
+    
+    # Set temperature effect to 0 if temperatures are outside thermal tolerance limits
+    above_max <- which(temp_at_t > species_params(params)$temp_max) 
+    below_min <- which(temp_at_t < species_params(params)$temp_min) 
+    
+    if (length(above_max) > 0) 
         scaled_temp_effect[above_max] = 0
-      
-      if (length(below_min) > 0) 
+    
+    if (length(below_min) > 0) 
         scaled_temp_effect[below_min] = 0 
-      
+    
+    scaled_temp_effect
+}
+
+therMizerEncounter <- function(params, n, n_pp, n_other, t, ...) {
+    
       # Calculate maximum possible encounter rate
-      max_encounter <- mizerEncounter(params, n = n, n_pp = n_pp, n_other = n_other, ...)
+      max_encounter <- mizerEncounter(params, n = n, n_pp = n_pp, n_other = n_other, t, ...)
       
       # Apply temperature effect
       # return(sweep(max_encounter, 1, scaled_temp_effect, '*', check.margin = FALSE))
-      return(max_encounter * scaled_temp_effect)
+      return(max_encounter * scaled_temp_effect(t))
       
 }
 
 therMizerPredMort <- function(params, n, n_pp, n_other, t, ...) {
-      
-      # Using t+1 to avoid calling ocean_temp[0,] at the first time step
-      temp_at_t <- other_params(params)$ocean_temp[t + 1,]
-  
-      # Calculate unscaled temperature effect using a generic polynomial rate equation
-      unscaled_temp_effect <- temp_at_t * (temp_at_t - species_params(params)$temp_min) * (species_params(params)$temp_max - temp_at_t)
-      
-      # Scale using new parameter
-      scaled_temp_effect <- unscaled_temp_effect / species_params(params)$encounterpred_scale
-      
-      # Set temperature effect to 0 if temperatures are outside thermal tolerance limits
-      above_max <- which(temp_at_t > species_params(params)$temp_max) 
-      below_min <- which(temp_at_t < species_params(params)$temp_min) 
-      
-      if (length(above_max) > 0) 
-        scaled_temp_effect[above_max] = 0
-      
-      if (length(below_min) > 0) 
-        scaled_temp_effect[below_min] = 0 
 
       # Calculate maximum possible encounter rate
-      max_predmort <- mizerPredMort(params, n = n, n_pp = n_pp, n_other = n_other, ...)
+      max_predmort <- mizerPredMort(params, n = n, n_pp = n_pp, n_other = n_other, t, ...)
       
       # Apply temperature effect
       # return(sweep(max_predmort, 1, scaled_temp_effect, '*', check.margin = FALSE))
-      return(max_predmort * scaled_temp_effect)
+      return(max_predmort * scaled_temp_effect(t))
       
 }
 
 therMizerResourceMort <- function(params, n, n_pp, n_other, t, ...) {
       
-      # Using t+1 to avoid calling ocean_temp[0,] at the first time step
-      temp_at_t <- other_params(params)$ocean_temp[t + 1,]
-  
-      # Calculate unscaled temperature effect using a generic polynomial rate equation
-      unscaled_temp_effect <- temp_at_t * (temp_at_t - species_params(params)$temp_min) * (species_params(params)$temp_max - temp_at_t)
-      
-      # Scale using new parameter
-      scaled_temp_effect <- unscaled_temp_effect / species_params(params)$encounterpred_scale
-      
-       # Set temperature effect to 0 if temperatures are outside thermal tolerance limits
-      above_max <- which(temp_at_t > species_params(params)$temp_max) 
-      below_min <- which(temp_at_t < species_params(params)$temp_min) 
-      
-      if (length(above_max) > 0) 
-        scaled_temp_effect[above_max] = 0
-      
-      if (length(below_min) > 0) 
-        scaled_temp_effect[below_min] = 0 
-      
       # Calculate maximum possible encounter rate
-      max_resourcemort <- mizerResourceMort(params, n = n, n_pp = n_pp, n_other = n_other, ...)
+      max_resourcemort <- mizerResourceMort(params, n = n, n_pp = n_pp, n_other = n_other, t, ...)
       
       # Apply temperature effect
       # return(sweep(max_resourcemort, 1, scaled_temp_effect, '*', check.margin = FALSE))
-      return(max_resourcemort * scaled_temp_effect)
+      return(max_resourcemort * scaled_temp_effect(t))
       
 }
 

--- a/therMizer_extension.Rmd
+++ b/therMizer_extension.Rmd
@@ -43,7 +43,8 @@ species_params$interaction_resource <- c(1,0.5)
 
 # create the param object
 # note: some def values are different from old mizer (e.g. kappa)
-params <- newMultispeciesParams(species_params, no_w = 200, kappa = 0.0001)
+params <- newMultispeciesParams(species_params, no_w = 200, kappa = 0.0001) |>
+    steady(tol = 0.001)
 
 # run projections:
 sim <- project(params, t_max = 500, effort = 0)


### PR DESCRIPTION
I like your stuff very much. You have really made excellent use of the extension mechanism in mizer.

You were quite right that if you scale the encounter rate at which predators encounter prey by predator-specific factors, then you also need to scale the rate at which these predators kill the prey by the same factors. However you do not achieve that by multiplying the prey mortality rate by the scaling factors, because the prey mortality is an array prey species x prey size. So you do not want to modify how "PredMort" and "ResourceMort" are calculated but you want to modify how "PredRate" is calculated.

I have made a few other cosmetic changes. For example I ran the newly created params object through `steady()` because I think that makes it easier to see the changes arising from your changed scenarios (forced plankton and changing temperature) without being swamped by the initial transients while the system goes towards steady state. 

I also cleaned up the code a bit so that it is more self-evident that you are indeed using the same scaling factor for encounter rate and for predation rate, as you should.